### PR TITLE
feat: add cocktail page

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -1,0 +1,5 @@
+import axios from 'axios';
+
+export const fetcher = (url) => axios.get(url).then((res) => res.data);
+
+export default null;

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
     "@emotion/styled": "^11.3.0",
     "@material-ui/core": "^4.11.4",
     "@material-ui/lab": "^4.0.0-alpha.58",
+    "axios": "^0.21.1",
     "lodash": "^4.17.21",
     "next": "^10.1.3",
     "react": "17.0.1",
-    "react-dom": "17.0.1"
+    "react-dom": "17.0.1",
+    "swr": "^0.5.6"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.12.1",

--- a/pages/api/recipes/[id].js
+++ b/pages/api/recipes/[id].js
@@ -1,0 +1,13 @@
+export default (req, res) => {
+  res.statusCode = 200;
+  res.json({
+    name: 'Martini',
+    based: 'Gin',
+    image: 'https://picsum.photos/seed/picsum/200/200',
+    tech: 'Stur',
+    ingredientList: [
+      { name: 'Dry Gin', volume: '2', unit: 'oz' },
+      { name: 'Dry Vermouth', volume: '1/3', unit: 'oz' },
+    ],
+  });
+};

--- a/pages/cocktail/Cocktail.js
+++ b/pages/cocktail/Cocktail.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { css } from '@emotion/react';
+
+import palette from 'styles/palette';
+
+import Layout from 'components/Layout';
+import RecipeItem from 'components/RecipeItem';
+
+const Cocktail = ({ item, error }) => {
+  const container = css`
+    display: flex;
+    flex-direction: column;
+  `;
+
+  const titleSection = css`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: calc(100vh - 3rem);
+    background: ${palette.gray[1]};
+
+    h1 {
+      font-family: 'Open Sans';
+      font-size: 2.5rem;
+    }
+  `;
+
+  return (
+    <Layout>
+      <div css={container}>
+        <section css={titleSection}>
+          <RecipeItem item={item} isLoading={!item && !error} />
+        </section>
+      </div>
+    </Layout>
+  );
+};
+
+export default Cocktail;

--- a/pages/cocktail/CocktailContainer.js
+++ b/pages/cocktail/CocktailContainer.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import useSWR from 'swr';
+
+import { fetcher } from 'lib/api';
+import Cocktail from './Cocktail';
+
+const CocktailContainer = () => {
+  const { data: item, error } = useSWR('/api/recipes/id', fetcher);
+
+  if (!item) return null;
+  return <Cocktail item={item} error={error} />;
+};
+
+export default CocktailContainer;

--- a/pages/cocktail/index.js
+++ b/pages/cocktail/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import CocktailContainer from './CocktailContainer';
+
+const CocktailPage = () => <CocktailContainer />;
+
+export default CocktailPage;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,11 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { css } from '@emotion/react';
 
-import { sampleRecipeitem } from 'lib/data';
 import palette from 'styles/palette';
 
 import Layout from 'components/Layout';
-import RecipeItem from 'components/RecipeItem';
 
 const container = css`
   display: flex;
@@ -26,22 +24,14 @@ const titleSection = css`
   }
 `;
 
-export default function Home({ item }) {
-  const [isLoading, setIsLoading] = useState(true);
-  useEffect(() => {
-    setTimeout(() => setIsLoading(false), [2000]);
-  }, []);
+export default function Home() {
   return (
     <Layout>
       <div css={container}>
-        <section css={titleSection}>
-          <RecipeItem item={item} isLoading={isLoading} />
-        </section>
+        <div css={titleSection}>
+          <h1>Main Page</h1>
+        </div>
       </div>
     </Layout>
   );
-}
-
-export async function getStaticProps() {
-  return { props: { item: sampleRecipeitem } };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1320,6 +1320,13 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.1.tgz#70a7855888e287f7add66002211a423937063eaf"
   integrity sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -2129,6 +2136,11 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+dequal@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
+
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
@@ -2830,6 +2842,11 @@ flatted@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.0.tgz#a5d06b4a8b01e3a63771daa5cb7a1903e2e57067"
   integrity sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==
+
+follow-redirects@^1.10.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
+  integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -6022,6 +6039,13 @@ supports-hyperlinks@^2.0.0:
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
+
+swr@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-0.5.6.tgz#70bfe9bc9d7ac49a064be4a0f4acf57982e55a31"
+  integrity sha512-Bmx3L4geMZjYT5S2Z6EE6/5Cx6v1Ka0LhqZKq8d6WL2eu9y6gHWz3dUzfIK/ymZVHVfwT/EweFXiYGgfifei3w==
+  dependencies:
+    dequal "2.0.2"
 
 symbol-observable@1.2.0:
   version "1.2.0"


### PR DESCRIPTION
- [get] cocktail recipe api 추가
- `/cocktail` page 추가
- `/cocktail` page에서 레시피 아이템을 fetching 하여 `RecipeItem` 컴포넌트 렌더링